### PR TITLE
[UI/UX] Show windows without info

### DIFF
--- a/src/ui/run-history-ui-handler.ts
+++ b/src/ui/run-history-ui-handler.ts
@@ -147,7 +147,8 @@ export default class RunHistoryUiHandler extends MessageUiHandler {
     if (timestamps.length > 1) {
       timestampsNo.sort((a, b) => b - a);
     }
-    const entryCount = timestamps.length;
+    const minEntry = 3;
+    const entryCount = minEntry >= timestamps.length ? minEntry : timestamps.length;
     for (let s = 0; s < entryCount; s++) {
       const entry = new RunEntryContainer(this.scene, response[timestampsNo[s]], s);
       this.scene.add.existing(entry);
@@ -224,8 +225,15 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
     this.slotId = slotId;
     this.entryData = entryData;
 
-    this.setup(this.entryData);
-
+    const slotWindow = addWindow(this.scene, 0, 0, 304, 52);
+    this.add(slotWindow);
+    if (entryData) {
+      this.setup(this.entryData);
+    } else {
+      const emptyLabel = addTextObject(this.scene, 152, 26, i18next.t("saveSlotSelectUiHandler:empty"), TextStyle.WINDOW);
+      emptyLabel.setOrigin(0.5, 0.5);
+      this.add(emptyLabel);
+    }
   }
 
   /**
@@ -242,9 +250,6 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
 
     const victory = run.isVictory;
     const data = this.scene.gameData.parseSessionData(JSON.stringify(run.entry));
-
-    const slotWindow = addWindow(this.scene, 0, 0, 304, 52);
-    this.add(slotWindow);
 
     // Run Result: Victory
     if (victory) {


### PR DESCRIPTION
If it doesn't go through the for loop, it doesn't create the windows, so when entering RUN_HISTORY mode without historical data, it only shows a solid color. This is avoided by conditioning the entryData and creating the window regardless of whether there is entryData or not and with minimum entry.

Or a message when no are history available like Egglist, but will may add more translations in it case.

@frutescens

## Before
![2024-08-20 21 29 12 localhost 27f6edf1ac36](https://github.com/user-attachments/assets/a844b3d8-2a78-4c0c-926d-e5955562d008)

## After
![2024-08-20 22 03 00 localhost e75d11ac48d3](https://github.com/user-attachments/assets/154229ba-52db-48c8-9c31-08eae3185a68)
